### PR TITLE
[#25] Improve CSS languages identifiers

### DIFF
--- a/Sources/Lux/Injection/FileInjectionService.swift
+++ b/Sources/Lux/Injection/FileInjectionService.swift
@@ -18,7 +18,7 @@ public struct FileInjectionService {
         #"|<pre[^<^>]*class="\#(identifiers)"[^<^>]*><code[^<^>]*>)"# +
         #"[^<^>]*<\/code><\/pre>"#
 
-        return try NSRegularExpression(pattern: pattern)
+        return try NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
     }
 
     public static func inject(in text: String, using injector: Injector) throws -> String {

--- a/Sources/Lux/InjectorImplementations/Json/JSONInjector.swift
+++ b/Sources/Lux/InjectorImplementations/Json/JSONInjector.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public final class JSONInjector: BaseInjector<JSONCategory> {
 
-    override var defaultLanguageIdentifiers: Set<String> { ["json", "Json", "JSON", "language-json", "language-Json", "language-JSON"] }
+    override var defaultLanguageIdentifiers: Set<String> { ["json", "lang-json", "language-json"] }
     override var plainRegexPattern: RegexPattern { .json }
     override var htmlRegexPattern: RegexPattern { .json }
 

--- a/Sources/Lux/InjectorImplementations/Plist/PlistInjector.swift
+++ b/Sources/Lux/InjectorImplementations/Plist/PlistInjector.swift
@@ -2,7 +2,7 @@ import Foundation
 
 open class PlistInjector: BaseInjector<PlistCategory> {
 
-    override var defaultLanguageIdentifiers: Set<String> { ["plist", "Plist", "PLIST", "language-plist", "language-Plist", "language-PLIST"] }
+    override var defaultLanguageIdentifiers: Set<String> { ["plist", "lang-plist", "language-plist"] }
 
     override var plainRegexPattern: RegexPattern { .plainXml }
     override var htmlRegexPattern: RegexPattern { .htmlXml }

--- a/Sources/Lux/InjectorImplementations/XMLEnhanced/XMLEnhancedInjector.swift
+++ b/Sources/Lux/InjectorImplementations/XMLEnhanced/XMLEnhancedInjector.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Inject strings into a text depending on the configuration or the delegate.
 public final class XMLEnhancedInjector: BaseInjector<XMLEnhancedCategory> {
 
-    override var defaultLanguageIdentifiers: Set<String> { ["xml", "Xml", "XML", "language-xml", "language-Xml", "language-XML"] }
+    override var defaultLanguageIdentifiers: Set<String> { ["xml", "lang-xml", "language-xml"] }
     override var plainRegexPattern: RegexPattern { .plainXml }
     override var htmlRegexPattern: RegexPattern { .htmlXml }
 

--- a/Sources/Lux/InjectorImplementations/Xml/XMLInjector.swift
+++ b/Sources/Lux/InjectorImplementations/Xml/XMLInjector.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Inject strings into a text depending on the configuration or the delegate.
 public final class XMLInjector: BaseInjector<XMLCategory> {
 
-    override var defaultLanguageIdentifiers: Set<String> { ["xml", "Xml", "XML", "language-xml", "language-Xml", "language-XML"] }
+    override var defaultLanguageIdentifiers: Set<String> { ["xml", "lang-xml", "language-xml"] }
     override var plainRegexPattern: RegexPattern { .plainXml }
     override var htmlRegexPattern: RegexPattern { .htmlXml }
 


### PR DESCRIPTION
Improved html languages identifiers

- Make the regex case insensitive
- Added the lang-[Format] option