### PR TITLE
Prepare for release and escaped quotes in JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. `Lux` adheres to [Semantic Versioning](http://semver.org).
 
 ---
+## [0.3.6](https://github.com/ABridoux/lux/tree/0.3.6) (04/07/2020)
+
+### Fixed
+- JSON escaped quotes (for real this time) with \",\n allowed and "," not required to end a string value
+
 ## [0.3.5](https://github.com/ABridoux/lux/tree/0.3.5) (02/07/2020)
 
 ### Added

--- a/Sources/Lux/Constants/Version.swift
+++ b/Sources/Lux/Constants/Version.swift
@@ -1,3 +1,3 @@
 public struct Version {
-    public static let current = "0.3.5"
+    public static let current = "0.3.6"
 }

--- a/Sources/Lux/InjectorImplementations/Json/JSONInjector.swift
+++ b/Sources/Lux/InjectorImplementations/Json/JSONInjector.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: Regex
 
 extension RegexPattern {
-    static let json = RegexPattern(#"\{|\}|\(|\)|\[|\]|,|"[^"]*"\s*:|".*"(?=,\n)"#, type: .plain)
+    static let json = RegexPattern(#"\{|\}|\(|\)|\[|\]|,|"[^"]*"\s*:|"([^"]|\\")*[^\\]""#, type: .plain)
 }
 
 // MARK: - Injector


### PR DESCRIPTION
### Fixed
- JSON escaped quotes (for real this time) with \",\n allowed and "," not required to end a string value