### PR TITLE
[#71] Plist escaped HTML entities

### DIFF
--- a/Sources/Lux/Injection/BaseInjector.swift
+++ b/Sources/Lux/Injection/BaseInjector.swift
@@ -15,12 +15,9 @@ open class BaseInjector<Cat: Category, Output: Appendable, Injection: InjectionT
     var textType: TextType
     var type: Injector
 
-    /// If true, the injector will find all HTML special characters and replace them before injecting. Useful for plain input which has to be rendered to HTML.
-    private var escapeHTML = false {
-        didSet {
-            textType = escapeHTML ? .plain : .html
-        }
-    }
+    /// If true, the injector will find all HTML special characters and replace them before injecting.
+    /// Useful for plain input which has to be rendered to HTML.
+    private(set) var escapeHTML = false
 
     public var delegate: Delegate
 
@@ -56,16 +53,25 @@ open class BaseInjector<Cat: Category, Output: Appendable, Injection: InjectionT
 
     // MARK: - Functions
 
-    static func lowercasedIdentifiers(for language: String) -> Set<String> { [language, "lang-\(language)", "language-\(language)"] }
+    static func lowercasedIdentifiers(for language: String) -> Set<String> { [language,
+                                                                              "lang-\(language)",
+                                                                                "language-\(language)"] }
 
     /// Inject modifiers to colorise an input String.
     /// - Parameter text: The text to colorise
     /// - Returns: The colorised text. The output type will depend of the Injector type you use: HTML String, Terminal: String, App: AttributedString. You can retrieve the `NSMutableString` value
     /// from an `AttributedString` with the `nsAttributedString` property.
-    open func inject(in text: String) -> Output {
-
+    public final func inject(in text: String) -> Output {
         let text = escapeHTML ? text.escapingHTMLEntities() : text
 
+        return inject(inEscapedHTMLEntities: text)
+    }
+
+    /// Inject modifiers to colorise an input String.
+    /// - Parameter text: The text to colorise, with escaped HTML entities if `escapeHTML` is `true`
+    /// - Returns: The colorised text. The output type will depend of the Injector type you use: HTML String, Terminal: String, App: AttributedString. You can retrieve the `NSMutableString` value
+    /// from an `AttributedString` with the `nsAttributedString` property.
+    func inject(inEscapedHTMLEntities text: String) -> Output {
         let modifiedInput = try? InjectionService.inject(Output.self, in: text, following: regexPattern) { match in
             let category = Cat(from: match)
 

--- a/Sources/Lux/InjectorImplementations/Plist/PlistInjector.swift
+++ b/Sources/Lux/InjectorImplementations/Plist/PlistInjector.swift
@@ -15,7 +15,7 @@ open class PlistInjector<Output: Appendable, Injection: InjectionType, InjType: 
 
     // MARK: - Functions
 
-    override open func inject(in text: String) -> Output {
+    override public func inject(inEscapedHTMLEntities text: String) -> Output {
         var currentOpenTagIsKey = false
 
         let modifiedInput = try? InjectionService.inject(Output.self, in: text, following: regexPattern) { match in

--- a/Sources/Lux/InjectorImplementations/Swift/SwiftInjector.swift
+++ b/Sources/Lux/InjectorImplementations/Swift/SwiftInjector.swift
@@ -34,7 +34,7 @@ public final class SwiftInjector<Output: Appendable, Injection: InjectionType, I
         return AttributedString(attributedString: nsAttrString)
     }
 
-    override public func inject(in text: String) -> Output {
+    override public func inject(inEscapedHTMLEntities text: String) -> Output {
         switch type {
         case is Terminal: return Output(injectString(in: text))
         case is Html: return Output(injectString(in: text))

--- a/Sources/Lux/Models/TerminalModifier.swift
+++ b/Sources/Lux/Models/TerminalModifier.swift
@@ -18,7 +18,7 @@ public struct TerminalModifier {
 }
 
 extension TerminalModifier {
-    
+
     /// Terminal modifier to reset the color modification
     public static var resetColors: TerminalModifier { TerminalModifier(raw: "\u{001B}[0;0m") }
 }


### PR DESCRIPTION
The `inject` function is now final. It has a public version, and the internal one (which can be overridden) inject in a text with escaped HTML entities

Closes #71 